### PR TITLE
Change default pin assignment in dmx.c to accomodate original beaglebone and newer black.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ Features
 
 * *Example DMX client scripts.* This comes with example client scripts in the `controller` directory to help you get started with your idea.
 
-* *Cheap.* No longer do you need a Mac Mini and ENTTEC DMX interface to run your lighting installation. Now all you need is an $80 BeagleBone and a $5 circuit.
+* *Cheap.* No longer do you need a Mac Mini and ENTTEC DMX interface to run your lighting installation. Now all you need is an $80 (ahem now $45!) BeagleBone and a $5 circuit.
 
 How to run: Software
 --------------------
 
-1. Run `modprobe uio_pruss`
+1. Run `modprobe uio_pruss`. *Note that step #1 is only valid with older pre 3.8 kernels such as the original Beaglebone (white). Since kernel 3.8 (BeagleBone black shipping or any newer Angstrom image for example) you should enable it in the device tree layout instead of modprobe (/boot). One persistent method is explained in the Issues #2 thread. [Issue #2](http://github.com/boxysean/beaglebone-DMX/issues/2)
 2. Launch DMX server: `cd` into `bin` and run `./dmx`
 3. Launch DMX client: run a DMX client script, e.g., `cd contollers; python cycle.py`
 
@@ -34,12 +34,12 @@ How to run: Hardware
 --------------------
 
 1. [Make this circuit.](http://code.google.com/p/tinkerit/wiki/DmxSimpleBuilding)
-2. Connect pin 3 of the BeagleBone's P8 header to the input (pin 4) of the IC.
+2. Connect pin 12* of the BeagleBone's P8 header to the input (pin 4) of the IC. (*Note: this was recently changed to pin 12 from pin 3 to accomodate both the original Beaglebone and black variant. See dmx.c history for details.)
 3. Connect pins 5, 6, and 7 to ground, signal, and signal inversion respectively to target unit.
 
 ![image of DMX circuit](http://www.arduino.cc/playground/uploads/DMX/send_sn75276a.jpg)
 
-You can change the Bone's pin by editing the defined pin in `src/dmx.c` and recompiling.
+You can change the Bone's pin by editing the defined pin and local export/unexport in `src/dmx.c` and recompiling.
 
 DMX Server Protocol
 -------------------
@@ -73,4 +73,4 @@ BeagleBone rev A6 running both the DMX server and a DMX client written in python
 How it works
 ------------
 
-This library takes advantage of the BeagleBone's PRU (Programmable Realtime Unit). The DMX server passes the DMX values to the BeagleBone's PRU, which is constantly bit-banging the DMX protocol in realtime. ([Read more.](http://blog.boxysean.com/2012/08/12/first-steps-with-the-beaglebone-pru/)) The hardware circuit converts the bit-banged protocol into [RS-485](http://en.wikipedia.org/wiki/RS-485), which is what all standard DMX units expect.
+This library takes advantage of the BeagleBone's PRU (Programmable Realtime Unit). The DMX server passes the DMX values to the BeagleBone's PRU, which is constantly bit-banging the DMX protocol in realtime. ([Read more.](http://blog.boxysean.com/2012/08/12/first-steps-with-the-beaglebone-pru/)) The hardware circuit converts the bit-banged protocol into [RS-485](http://en.wikipedia.org/wiki/RS-485), which is what all standard DMX units expect. For help with the newer kernel 3.8 device tree, gpio names, pin #s and assignments this was a good resource [derek molloy boneDeviceTree docs](http://github.com/derekmolloy/boneDeviceTree/tree/master/docs).

--- a/src/dmx.c
+++ b/src/dmx.c
@@ -29,8 +29,9 @@
 
 #define PRU_NUM 	0
 
-// This pin is pin 3 on the P8 header
-#define DMX_PIN (6)
+// def dmx_pin 6 is physical pin 3 on the P8 header or gpio 38
+// def dmx_pin 12 is physical pin 12 on the P8 header or gpio 44
+#define DMX_PIN (12)
 #define DMX_CHANNELS (2)
 
 #define DMX_HALT_ADDR (0x100)
@@ -87,7 +88,9 @@ int main (void)
     /* Initialize the PRU */
     prussdrv_init ();		
 
-    LOCAL_export_pin(38);
+    /* physical pin 3 on the P8 header is gpio 38 */
+    /* physical pin 12 on the P8 header is gpio 44 */
+    LOCAL_export_pin(44);
     
     /* Open PRU Interrupt */
     ret = prussdrv_open(PRU_EVTOUT_0);
@@ -121,7 +124,8 @@ int main (void)
     prussdrv_pru_disable (PRU_NUM);
     prussdrv_exit ();
 
-    LOCAL_unexport_pin(38);
+    /* see comments above */
+    LOCAL_unexport_pin(44);
 
     return(0);
 


### PR DESCRIPTION
Change default pin assignment in dmx.c to accomodate original beaglebone and newer black.
Changed from header P8 pin 3 to P8 pin 12. The new beaglebone black has a emmc dependency that made pin 3 unusable. README updated to include new uio_pruss enable information and additional notes as well.
This change makes it so any new DMX capes created would work on both beaglebones.
